### PR TITLE
開始時間を指定できるようにする

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,13 @@ function main(){ // ページを開いて最初にやること
     }
     document.querySelector("#Zikyu").value = +urlData.zikyu ? +urlData.zikyu : 1200
     PassSec = +urlData.s ? +urlData.s : 0 // 秒を設定
+    if(urlData.flag == "true"|| (urlData.start ? /^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(urlData.start) : false)){
+        const setTimeInput = document.createElement("input")
+        setTimeInput.setAttribute("type", "time")
+        setTimeInput.setAttribute("id", "startTime")
+        setTimeInput.setAttribute("value", urlData.start ? urlData.start : "10:00")
+        document.querySelector(".controller").appendChild(setTimeInput)
+    }
 }
 
 main()

--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 var PassSec = 0;
 function start() {
+    // 開始時間を設定した場合に情報を追加する
+    // 日付超えて働かない前提でコードを書く
+    if(document.querySelector("#startTime")){
+        const startTimeAry = document.querySelector("#startTime").value.split(":")
+        const startTimeS = +startTimeAry[0] * 3600 + +startTimeAry[1] * 60
+        const now = new Date()
+        const nowS = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds()
+        PassSec = nowS - startTimeS
+    }
     PassageID = setInterval('showPassage()',1000);
     document.getElementById("start").disabled = true;
     document.getElementById("reset").disabled = true;


### PR DESCRIPTION
# やったこと
開始時間を指定した場合、スタートを押したタイミングと比較して、途中からタイマーをできるようにする

# クエリパラメーター
- `flag` : trueを指定すると、開始時間指定モードにする。（初期値は10:00）
- `start` : `hh:mm`形式で開始時間を指定する。（このパラメーターを指定した場合は、開始時間指定モードになる）
    - もし形式が合わなかった場合は、開始時間指定モードにならない

# 使い方
- https://kohaku0822.github.io/kyuryo_timer/?start=12:00
- https://kohaku0822.github.io/kyuryo_timer/?flag=true